### PR TITLE
Add "unsupported" status and EOL page

### DIFF
--- a/toolkit/docs/5.2.5-EOL.html
+++ b/toolkit/docs/5.2.5-EOL.html
@@ -1,0 +1,83 @@
+<?php
+
+$title = "Upgrading from unsupported Globus 5.2 packages";
+
+include_once( "/mcs/www-unix.globus.org/include/globus_header.inc" ); 
+?>
+
+<h1><?php echo $title; ?></h1>
+
+<h2>Fedora/CentOS/RHEL/Scientific</h2>
+<p>There is no issue here because all supported repo versions are using GT 6.</p>
+
+<h2>Debian/Ubuntu</h2>
+<p>This is an issue for Debian 7, 8 and Ubuntu 12.04, 14.04.</p>
+
+<p>For Debian 7 and 8, GT 6 has been added to the versions backports repo.  See instructions below for upgrading.</p>
+
+<p>For Ubuntu 12.04, we do not have plans for adding GT6 to its' backport repo because it will be going out of support soon and to our knowledge, this is not needed by the Globus community.</p>
+
+<p>For Ubuntu 14.04, no one has needed support for this yet.  We will if there is sufficient need.  Contact me if you will need support for this.</p>
+
+<h1>Upgrade from Debian distro repo versions to either backports or GT repo versions</h1>
+
+<p>The Globus repo is recommended if you will be using the Globus packages only, and aren't using other packages from backports that depend on Globus packages. The packages in this repo will probably be updated faster/more frequently than the packages in backports, but there could be compatibility issues if you are using other packages in backports that depend on the Globus packages in backports.</p>
+
+<p>To go from distro repo to Globus repo:</p>
+
+<ol>
+	<li>Remove packages currently on system that were installed from distro repo that will be replaced by packages from the Globus repo
+	<ul>
+		<li>If all Globus packages were installed from distro repo then something like: apt-get remove ".*globus.*"</li>
+		<li>For MyProxy: apt-get remove ".*myproxy.*"</li>
+		<li>For gsi-openssh: apt-get remove gsi-openssh.*</li>
+		<li>This will remove packages but preserve config files</li></ul>
+	<li>Install Globus repo</li>
+	<ul>
+		<li>wget http://toolkit.globus.org/ftppub/gt6/installers/repo/globus-toolkit-repo_latest_all.deb</li>
+		<li>dpkg -i globus-toolkit-repo_latest_all.deb</li></ul>
+	<li>Install desired Globus packages from Globus repo</li>
+	<ul>
+		<li>e.g. - apt-get install globus-gridftp-server-progs myproxy-server myproxy-admin</li>
+		<li>If/when prompted, keep old config files</li></ul>
+	<li>Start services and test functionality</li>
+	<ul>
+		<li>There is a chance that there may have been changes to the syntax for certain options in the config files for some components of the Globus Toolkit from the version of the Globus Toolkit you were using to GT6. If any of the services don't start or don't function properly, then check the config files for that service against the GT 6 documentation for that service here:
+		<ul>
+			<li><a href="http://toolkit.globus.org/toolkit/docs/latest-stable/">http://toolkit.globus.org/toolkit/docs/latest-stable/</a></li></ul></ul></ol>
+
+<p>The backports repo is recommended if you are using other packages from backports that depend on the Globus packages you want to use.</p>
+
+<p>To go from distro repo to backports repo:</p>
+
+<ol>
+	<li>Remove Globus packages currently on system that were installed from distro repo
+		<ul>
+			<li>If all Globus packages were installed from distro repo then something like: apt-get remove ".*globus.*"</li>
+			<li>This will remove packages but preserve config files</li></ul></li>
+	<li>Enable backports repo
+		<ul>
+			<li><a href="http://backports.debian.org/Instructions/">http://backports.debian.org/Instructions/</a></li></ul></li>
+	<li>Install desired Globus packages from backports repo
+	<ul>
+		<li>e.g. - apt-get -t NAME_OF_BACKPORTS_REPO globus-gridftp-server-progs
+			<ul>
+				<li>Alternately, it is possible to create a .pref file in /etc/apt/preferences.d/ and specify a set of packages you'd like to automatically be pulled from the backports repo without having to use the -t option to explicitly declare this when installing the package - e.g.:
+					<ul>
+						<pre>Package: globus-* libglobus-*<br/>Pin: release a=NAME_OF_BACKPORTS_REPO<br/>Pin-Priority: 500</pre></ul></li>
+				<li>With a file in /etc/apt/preferences.d/ specifying the above config, the following command would then automatically pull the specified packages from the backports repo:
+					<ul>
+						<li>apt-get globus-gridftp-server-progs globus-core globus-gram-job-manager</li></ul></li>
+				<li>This method should only be used if you're certain that you want any package matching the specified pattern to automatically be pulled from the backports repo.</li></ul></li>
+		<li>If/when prompted, keep old config files</li></ul></li>
+	<li>Start services and test functionality
+		<ul>
+			<li>There is a chance that there may have been changes to the syntax for certain options in the config files for some components of the Globus Toolkit from the version of the Globus Toolkit you were using to GT6. If any of the services don't start or don't function properly, then check the config files for that service against the GT 6 documentation for that service here:
+				<ul>
+					<li><a href="http://toolkit.globus.org/toolkit/docs/latest-stable/">http://toolkit.globus.org/toolkit/docs/latest-stable/</a></li></ul></li></ul></li></ol>
+
+
+
+
+<?php include("http://www-unix.globus.org/include/globus_footer.inc"); ?>
+

--- a/toolkit/docs/5.2/5.2.0/index.xml
+++ b/toolkit/docs/5.2/5.2.0/index.xml
@@ -4,6 +4,7 @@
 <article id="gt">
             <title>Globus Toolkit <replaceable role="entity">version</replaceable> Release
                         Manuals</title>
+            <para><b><ulink url="http://toolkit.globus.org/toolkit/5.2.5-EOL.html">This version has been EOL’d</ulink></b></para>
             <para>The following documents are good places to start with Globus Toolkit <replaceable
                                     role="entity">version</replaceable>:</para>
             <itemizedlist>

--- a/toolkit/docs/5.2/5.2.1/index.xml
+++ b/toolkit/docs/5.2/5.2.1/index.xml
@@ -4,6 +4,7 @@
 <article id="gt">
             <title>Globus Toolkit <replaceable role="entity">version</replaceable> Release
                         Manuals</title>
+            <para><b><ulink url="http://toolkit.globus.org/toolkit/5.2.5-EOL.html">This version has been EOL’d</ulink></b></para>
             <para>The following documents are good places to start with Globus Toolkit <replaceable
                                     role="entity">version</replaceable>:</para>
             <itemizedlist>

--- a/toolkit/docs/5.2/5.2.2/index.xml
+++ b/toolkit/docs/5.2/5.2.2/index.xml
@@ -4,6 +4,7 @@
 <article id="gt">
             <title>Globus Toolkit <replaceable role="entity">version</replaceable> Release
                         Manuals</title>
+            <para><b><ulink url="http://toolkit.globus.org/toolkit/5.2.5-EOL.html">This version has been EOL’d</ulink></b></para>
             <para>The following documents are good places to start with Globus Toolkit <replaceable
                                     role="entity">version</replaceable>:</para>
             <itemizedlist>

--- a/toolkit/docs/5.2/5.2.3/index.xml
+++ b/toolkit/docs/5.2/5.2.3/index.xml
@@ -4,6 +4,7 @@
 <article id="gt">
             <title>Globus Toolkit <replaceable role="entity">version</replaceable> Release
                         Manuals</title>
+            <para><b><ulink url="http://toolkit.globus.org/toolkit/5.2.5-EOL.html">This version has been EOL’d</ulink></b></para>
             <para>The following documents are good places to start with Globus Toolkit <replaceable
                                     role="entity">version</replaceable>:</para>
             <itemizedlist>

--- a/toolkit/docs/5.2/5.2.4/index.xml
+++ b/toolkit/docs/5.2/5.2.4/index.xml
@@ -4,6 +4,7 @@
 <article id="gt">
             <title>Globus Toolkit <replaceable role="entity">version</replaceable> Release
                         Manuals</title>
+            <para><b><ulink url="http://toolkit.globus.org/toolkit/5.2.5-EOL.html">This version has been EOL’d</ulink></b></para>
             <para>The following documents are good places to start with Globus Toolkit <replaceable
                                     role="entity">version</replaceable>:</para>
             <itemizedlist>

--- a/toolkit/docs/5.2/5.2.5/index.xml
+++ b/toolkit/docs/5.2/5.2.5/index.xml
@@ -4,6 +4,7 @@
 <article id="gt">
             <title>Globus Toolkit <replaceable role="entity">version</replaceable> Release
                         Manuals</title>
+            <para><b><ulink url="http://toolkit.globus.org/toolkit/5.2.5-EOL.html">This version has been EOL’d</ulink></b></para>
             <para>The following documents are good places to start with Globus Toolkit <replaceable
                                     role="entity">version</replaceable>:</para>
             <itemizedlist>

--- a/toolkit/docs/5.2/index.html
+++ b/toolkit/docs/5.2/index.html
@@ -9,8 +9,9 @@ include_once( "/mcs/www-unix.globus.org/include/globus_header.inc" );
 
 <p>This page  includes links to documentation
   for all point versions of Globus Toolkit 5.2+.</p>
+<p><b>All versions are unsupported.</b></p>
 <ul>
-<li><a href="5.2.5/">5.2.5 Release Documentation</a> (recommended)</li>
+<li><a href="5.2.5/">5.2.5 Release Documentation</a></li>
 <li><a href="5.2.4/">5.2.4 Release Documentation</a></li>
 <li><a href="5.2.3/">5.2.3 Release Documentation</a></li>
 <li><a href="5.2.2/">5.2.2 Release Documentation</a></li>

--- a/toolkit/docs/index.html
+++ b/toolkit/docs/index.html
@@ -13,20 +13,20 @@ include_once( "/mcs/www-unix.globus.org/include/globus_header.inc" );
   <li>Stable Release Documentation
       <ul>
       <li><a href="6.0/">5.2 Stable Release Documentation</a> </li>
-      <li><a href="5.2/">5.2 Stable Release Documentation</a> </li>
+      <li><a href="5.2/">5.2 Stable Release Documentation</a> (not supported)</li>
        <li><a href="5.0/">5.0 Stable Release Documentation</a> (not supported)</li>
         <li><a href="4.2/">4.2 Stable Release Documentation</a> (not supported)</li>
         <li><a href="4.0/">4.0 Stable Release Documentation</a> (not supported)</li>
         <li><a href="3.2/">3.2
           Stable Release Documentation</a> (not supported)</li>
         <li><a href="3.0/">3.0
-            Stable Release Documentation</a>  (not supported)</li>
+            Stable Release Documentation</a> (not supported)</li>
         <li><a href="2.4/">2.4
-            Stable Release Documentation</a>  (not supported)</li>
+            Stable Release Documentation</a> (not supported)</li>
       </ul>
   </li>
   <li><a href="development/">Development
-      Release Documentation</a>  (not supported)</li>
+      Release Documentation</a> (not supported)</li>
 </ul>
 
 <?php include("http://www-unix.globus.org/include/globus_footer.inc"); ?>

--- a/toolkit/downloads/index.html
+++ b/toolkit/downloads/index.html
@@ -7,7 +7,7 @@ include_once( "/mcs/www-unix.globus.org/include/globus_header.inc" );
 
 <h1><?php echo $title; ?></h1>
 <p> In production settings, users should continue to use one of the two officially
-  supported stable releases (GT 5.2.0 is highly recommended.) More information on stable and development releases can be found
+  supported stable releases (GT 6.0 is highly recommended.) More information on stable and development releases can be found
 at <a href="http://www.globus.org/toolkit/versioning.html">http://www.globus.org/toolkit/versioning.html </a></p>
 <ul>
   <li> <a href="#stable">Stable Releases</a></li>
@@ -24,18 +24,18 @@ fixes. </p>
 <p>Below are links to the <strong>stable</strong> versions of the Globus
     Toolkit:</p>
 <ul>
-  <li><a href="5.2.5/">Globus Toolkit 5.2.5 Downloads</a> <span class="panel">(recommended 5.2 release)</span></li>
-  <li><a href="5.2.4/">Globus Toolkit 5.2.4 Downloads</a></li>
-  <li><a href="5.2.3/">Globus Toolkit 5.2.3 Downloads</a></li>
-  <li><a href="5.2.2/">Globus Toolkit 5.2.2 Downloads</a></li>
-  <li><a href="5.2.1/">Globus Toolkit 5.2.1 Downloads</a></li>
-  <li><a href="5.2.0/">Globus Toolkit 5.2.0 Downloads</a></li>
-  <li><a href="5.0.5/">Globus Toolkit 5.0.5 Downloads</a> <span class="panel">(recommended 5.0 release)</span></li>
-  <li><a href="5.0.4/">Globus Toolkit 5.0.4 Downloads</a></li>
-  <li><a href="5.0.3/">Globus Toolkit 5.0.3 Downloads</a></li>
-  <li><a href="5.0.2/">Globus Toolkit 5.0.2 Downloads</a></li>
-  <li><a href="5.0.1/">Globus Toolkit 5.0.1 Downloads</a></li>
-  <li><a href="5.0.0/">Globus Toolkit 5.0.0 Downloads</a></li>
+  <li><a href="5.2.5/">Globus Toolkit 5.2.5 Downloads</a> (not supported)</li>
+  <li><a href="5.2.4/">Globus Toolkit 5.2.4 Downloads</a> (not supported)</li>
+  <li><a href="5.2.3/">Globus Toolkit 5.2.3 Downloads</a> (not supported)</li>
+  <li><a href="5.2.2/">Globus Toolkit 5.2.2 Downloads</a> (not supported)</li>
+  <li><a href="5.2.1/">Globus Toolkit 5.2.1 Downloads</a> (not supported)</li>
+  <li><a href="5.2.0/">Globus Toolkit 5.2.0 Downloads</a> (not supported)</li>
+  <li><a href="5.0.5/">Globus Toolkit 5.0.5 Downloads</a> (not supported)</li>
+  <li><a href="5.0.4/">Globus Toolkit 5.0.4 Downloads</a> (not supported)</li>
+  <li><a href="5.0.3/">Globus Toolkit 5.0.3 Downloads</a> (not supported)</li>
+  <li><a href="5.0.2/">Globus Toolkit 5.0.2 Downloads</a> (not supported)</li>
+  <li><a href="5.0.1/">Globus Toolkit 5.0.1 Downloads</a> (not supported)</li>
+  <li><a href="5.0.0/">Globus Toolkit 5.0.0 Downloads</a> (not supported)</li>
   <li><a href="4.2.1/">Globus Toolkit 4.2.1 Downloads</a> (not supported)</li>
   <li><a href="4.2.0/">Globus Toolkit 4.2.0 Downloads</a> (not supported)</li>
   <li><a href="4.0.8/">Globus Toolkit 4.0.8 Downloads</a> (not supported)</li>

--- a/toolkit/downloads/index.html
+++ b/toolkit/downloads/index.html
@@ -24,6 +24,7 @@ fixes. </p>
 <p>Below are links to the <strong>stable</strong> versions of the Globus
     Toolkit:</p>
 <ul>
+  <li><a href="6.0/">Globus Toolkit 6.0 Downloads</a> <span class="panel">(recommended GT6 release)</span></li>
   <li><a href="5.2.5/">Globus Toolkit 5.2.5 Downloads</a> (not supported)</li>
   <li><a href="5.2.4/">Globus Toolkit 5.2.4 Downloads</a> (not supported)</li>
   <li><a href="5.2.3/">Globus Toolkit 5.2.3 Downloads</a> (not supported)</li>


### PR DESCRIPTION
- Add a new page for upgrading from GT 5.2.5 to GT 6 (http://toolkit.globus.org/toolkit/5.2.5-EOL.html)
- http://toolkit.globus.org/toolkit/docs/5.2/ - Add all versions unsupported
- http://toolkit.globus.org/toolkit/docs/ - Add all versions except for 6.0 as unsupported
- http://toolkit.globus.org/toolkit/docs/5.2/5.2.5/ - Add a banner/line stating this version has been EOL’d (link to 5.2-EOL.html)

Definitely need to check my syntax for the link to the 5.2.5-EOL.html since I couldn't test it and am not as familiar with docbook.
